### PR TITLE
refactor: modernize typing now that 3.8 support is dropped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ line-length = 127
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "C90"]
+select = ["E", "F", "W", "C90", "UP"]
 mccabe = { max-complexity = 10 }

--- a/src/snakestream/base_stream.py
+++ b/src/snakestream/base_stream.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterable, Callable, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import AsyncGenerator, AsyncIterable
 
 from snakestream.type import CloseHandler
 
@@ -16,19 +19,19 @@ async def _normalize(source: Any) -> AsyncGenerator:
         yield source
 
 
-def _accept(source: Any) -> Optional[AsyncGenerator]:
+def _accept(source: Any) -> AsyncGenerator | None:
     if isinstance(source, AsyncGenerator) or isinstance(source, AsyncIterable):
         return source
     return None
 
 
-class BaseStream():
+class BaseStream:
     def __init__(self, source: Any) -> None:
         self._stream = _accept(source) or _normalize(source)
-        self._chain: List[Callable] = []
+        self._chain: list[Callable] = []
         self._close_handlers = []
 
-    def _sequential(self, intermediaries: List[Callable], iterable: AsyncGenerator) -> AsyncGenerator:
+    def _sequential(self, intermediaries: list[Callable], iterable: AsyncGenerator) -> AsyncGenerator:
         if len(intermediaries) == 0:
             return iterable
         if len(intermediaries) == 1:
@@ -40,17 +43,17 @@ class BaseStream():
     def _compose(self) -> AsyncGenerator:
         return self._sequential(self._chain, self._stream)
 
-    def sequential(self) -> 'Stream':
+    def sequential(self) -> Stream:
         from .stream import Stream
         new_source = self._compose()
         return Stream(new_source, self._close_handlers)
 
-    def parallel(self) -> 'Stream':
+    def parallel(self) -> Stream:
         from .parallel_stream import ParallelStream
         new_source = self._compose()
         return ParallelStream(new_source, self._close_handlers)
 
-    def on_close(self, close_handler: CloseHandler) -> 'Stream':
+    def on_close(self, close_handler: CloseHandler) -> Stream:
         self._close_handlers.append(close_handler)
         return self
 

--- a/src/snakestream/collector.py
+++ b/src/snakestream/collector.py
@@ -3,7 +3,10 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=invalid-name
 
-from typing import AsyncGenerator, Any, List
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import AsyncGenerator
 
 
 async def to_generator(composition: AsyncGenerator) -> AsyncGenerator[Any, None]:
@@ -11,7 +14,7 @@ async def to_generator(composition: AsyncGenerator) -> AsyncGenerator[Any, None]
         yield n
 
 
-async def to_list(composition: AsyncGenerator) -> List[Any]:
+async def to_list(composition: AsyncGenerator) -> list[Any]:
     ret = []
     async for n in composition:
         ret.append(n)

--- a/src/snakestream/parallel_stream.py
+++ b/src/snakestream/parallel_stream.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, AsyncGenerator, Callable, List, Optional
+from typing import Any, Callable
+from collections.abc import AsyncGenerator
 from snakestream.stream import PROCESSES, Stream
 from snakestream.type import CloseHandler
 
 
 class ParallelStream(Stream):
-    def __init__(self, source: Any, close_handlers: Optional[List[CloseHandler]] = None) -> None:
+    def __init__(self, source: Any, close_handlers: list[CloseHandler] | None = None) -> None:
         super().__init__(source)
         self._close_handlers = close_handlers or []
 
@@ -14,7 +17,7 @@ class ParallelStream(Stream):
 
     async def _parallel(
         self,
-        intermediaries: List[Callable],
+        intermediaries: list[Callable],
         iterable: AsyncGenerator,
         processes: int = PROCESSES
     ) -> AsyncGenerator:

--- a/src/snakestream/stream.py
+++ b/src/snakestream/stream.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from functools import cmp_to_key
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Callable, Generator, Optional, List, \
-    Union, AsyncGenerator, Any
+from typing import TYPE_CHECKING, Callable, Any
+from collections.abc import Generator, AsyncGenerator
 
 from snakestream.base_stream import BaseStream
 from snakestream.collector import to_generator
@@ -21,7 +21,7 @@ PROCESSES: int = 4
 _UNSET = object()
 
 
-async def _concat(a: 'Stream', b: 'Stream') -> AsyncGenerator:
+async def _concat(a: Stream, b: Stream) -> AsyncGenerator:
     async for i in a._compose():
         yield i
     async for j in b._compose():
@@ -29,12 +29,12 @@ async def _concat(a: 'Stream', b: 'Stream') -> AsyncGenerator:
 
 
 class Stream(BaseStream):
-    def __init__(self, source: Any, close_handlers: Optional[List[CloseHandler]] = None) -> None:
+    def __init__(self, source: Any, close_handlers: list[CloseHandler] | None = None) -> None:
         super().__init__(source)
         self._close_handlers = close_handlers or []
 
     @staticmethod
-    def of(*args, **kwargs) -> 'Stream':
+    def of(*args, **kwargs) -> Stream:
         source = []
 
         if args and len(args) == 1:
@@ -58,16 +58,16 @@ class Stream(BaseStream):
         return Stream(source)
 
     @staticmethod
-    def empty() -> 'Stream':
+    def empty() -> Stream:
         return Stream([])
 
     @staticmethod
-    async def concat(a: 'Stream', b: 'Stream') -> 'Stream':
+    async def concat(a: Stream, b: Stream) -> Stream:
         new_stream = _concat(a, b)
         return Stream(new_stream)
 
     @staticmethod
-    def builder() -> 'StreamBuilder':
+    def builder() -> StreamBuilder:
         from snakestream.stream_builder import StreamBuilder
         return StreamBuilder()
 
@@ -82,7 +82,7 @@ class Stream(BaseStream):
         return Stream.of(_make_iterator(seed, nxt))
 
     # Intermediaries
-    def filter(self, predicate: Predicate) -> 'Stream':
+    def filter(self, predicate: Predicate) -> Stream:
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
             async for i in iterable:
                 if iscoroutinefunction(predicate):
@@ -95,7 +95,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def map(self, mapper: Mapper) -> 'Stream':
+    def map(self, mapper: Mapper) -> Stream:
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
             async for i in iterable:
                 if iscoroutinefunction(mapper):
@@ -106,7 +106,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def flat_map(self, flat_mapper: FlatMapper) -> 'Stream':
+    def flat_map(self, flat_mapper: FlatMapper) -> Stream:
         if iscoroutinefunction(flat_mapper):
             raise StreamBuildException("flat_map() does not support coroutines")
 
@@ -118,7 +118,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def sorted(self, comparator: Optional[Comparator] = None, reverse=False) -> 'Stream':
+    def sorted(self, comparator: Comparator | None = None, reverse=False) -> Stream:
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
             # unfortunately I now don't see other way than to block the entire stream
             # how can I otherwise know what is the first item out?
@@ -144,7 +144,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def distinct(self) -> 'Stream':
+    def distinct(self) -> Stream:
         seen = set()
 
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
@@ -158,7 +158,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def peek(self, consumer: Consumer) -> 'Stream':
+    def peek(self, consumer: Consumer) -> Stream:
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
             async for i in iterable:
                 if iscoroutinefunction(consumer):
@@ -170,7 +170,7 @@ class Stream(BaseStream):
         self._chain.append(fn)
         return self
 
-    def limit(self, max_size: int) -> 'Stream':
+    def limit(self, max_size: int) -> Stream:
         size = 0
 
         async def fn(iterable: AsyncGenerator) -> AsyncGenerator:
@@ -186,10 +186,10 @@ class Stream(BaseStream):
         return self
 
     # Terminals
-    def collect(self, collector: Callable) -> Union[List, AsyncGenerator]:
+    def collect(self, collector: Callable) -> list | AsyncGenerator:
         return collector(self._compose())
 
-    async def reduce(self, identity: Union[T, R], accumulator: Accumulator) -> Union[T, R]:
+    async def reduce(self, identity: T | R, accumulator: Accumulator) -> T | R:
         async for n in self._compose():
             if iscoroutinefunction(accumulator):
                 identity = await accumulator(identity, n)
@@ -212,14 +212,14 @@ class Stream(BaseStream):
         return await self.find_any()
     '''
 
-    async def find_any(self) -> Optional[Any]:
+    async def find_any(self) -> Any | None:
         async for n in self._compose():
             return n
 
-    async def max(self, comparator: Comparator) -> Optional[T]:
+    async def max(self, comparator: Comparator) -> T | None:
         return await self._min_max(comparator)
 
-    async def min(self, comparator: Comparator) -> Optional[T]:
+    async def min(self, comparator: Comparator) -> T | None:
         if iscoroutinefunction(comparator):
             async def negative_comparator(x, y):
                 return not await comparator(x, y)
@@ -229,7 +229,7 @@ class Stream(BaseStream):
                 return not comparator(x, y)
             return await self._min_max(negative_comparator)
 
-    async def _min_max(self, comparator: Comparator) -> Optional[T]:
+    async def _min_max(self, comparator: Comparator) -> T | None:
         found = _UNSET
         async for n in self._compose():
             if found is _UNSET:

--- a/src/snakestream/stream_builder.py
+++ b/src/snakestream/stream_builder.py
@@ -1,19 +1,19 @@
-from typing import List
+from __future__ import annotations
 
 from snakestream.stream import Stream
 from snakestream.type import T
 
 
-class StreamBuilder():
+class StreamBuilder:
     def __init__(self) -> None:
-        self._elements: List[T] = []
+        self._elements: list[T] = []
 
-    def add(self, element: T) -> 'StreamBuilder':
+    def add(self, element: T) -> StreamBuilder:
         self.accept(element)
         return self
 
     def accept(self, element: T) -> None:
         self._elements.append(element)
 
-    def build(self) -> 'Stream':
+    def build(self) -> Stream:
         return Stream(self._elements)

--- a/src/snakestream/type.py
+++ b/src/snakestream/type.py
@@ -1,5 +1,5 @@
-from typing import TYPE_CHECKING, AsyncGenerator, \
-    AsyncIterable, Awaitable, Callable, Generator, Iterable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Generator, Iterable
 
 if TYPE_CHECKING:
     from snakestream.stream import Stream  # pragma: no cover

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 import pytest
 
 from snakestream import Stream

--- a/tests/test_of.py
+++ b/tests/test_of.py
@@ -3,7 +3,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=invalid-name
 
-from typing import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator
 import pytest
 
 from snakestream import Stream
@@ -16,8 +16,7 @@ async def async_generator() -> AsyncGenerator:
 
 
 def generator() -> Generator:
-    for i in range(1, 6):
-        yield i
+    yield from range(1, 6)
 
 
 class AsyncIteratorImpl:


### PR DESCRIPTION
Enable ruff's pyupgrade (UP) rules and apply them: switch to PEP 585 builtin generics and PEP 604 unions (list, X | None) instead of typing.List/Optional/Union, import ABCs from collections.abc, and drop other now-unnecessary constructs the rule set caught.