### PR TITLE
docs: confirm branch coverage is already gated, archive openspec change

### DIFF
--- a/openspec/changes/archive/2026-08-10-gate-branch-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-gate-branch-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-gate-branch-coverage/design.md
+++ b/openspec/changes/archive/2026-08-10-gate-branch-coverage/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`pyproject.toml` sets `[tool.coverage.run] branch = true`, so `coverage.py` already collects branch-arc data alongside line data. CI (`.github/workflows/check.yml`) runs `uv run pytest --cov-fail-under=98` only on the Python 3.14 leg — a deliberate choice (documented in a comment) because branch-arc measurement for `async for` loops differs across CPython versions and produces spurious failures on older interpreters.
+
+The open question this change resolves: does `--cov-fail-under=98` (a `pytest-cov` flag, forwarded to `coverage.py`) actually gate on combined line+branch coverage, or only on line coverage, with `branch = true` silently doing nothing for enforcement purposes?
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish, with evidence, whether the existing `--cov-fail-under=98` gate already reflects combined line+branch coverage.
+- If it does not, add the minimum config change needed to make it so, without altering the 98% threshold or the single-Python-version enforcement strategy.
+- Leave a trace (test and/or comment) so this doesn't need re-litigating later.
+
+**Non-Goals:**
+- Changing the 98% threshold value.
+- Enforcing coverage on every matrix leg (the cross-version measurement issue is out of scope here).
+- Introducing a new coverage tool or reporting format.
+
+## Decisions
+
+- **How to verify**: introduce a throwaway, deliberately-partial branch (an `if`/`else` where only one side is exercised by tests) in a scratch/local run of `coverage report`, confirm the percentage drops and `--cov-fail-under` fails, then revert the scratch code. This directly demonstrates whether branch misses affect the gate. `coverage.py`'s documented behavior is that with `branch = true`, the reported "percent covered" already combines statement and branch execution into one ratio — so `--cov-fail-under` should already be a combined gate. This step confirms that's true in this project's actual config rather than assuming it from documentation alone.
+- **Where to encode the finding**: prefer a comment in `pyproject.toml` next to `branch = true` over a new CI step, since the mechanism (if already working) needs no code change — only a record of why no further action was taken. This keeps the change additive and avoids duplicating enforcement.
+- **If a real gap is found**: the fallback is `[tool.coverage.report] fail_under = 98` (coverage-native) instead of the `pytest-cov` CLI flag, since `fail_under` in `[tool.coverage.report]` is unambiguously the combined-metric gate per coverage.py's own semantics. This would replace, not duplicate, the existing `--cov-fail-under` flag to avoid two sources of truth for the threshold.
+
+## Risks / Trade-offs
+
+- [Risk] A scratch/local verification step is manual and not repeatable in CI → Mitigation: if the verification confirms current behavior is correct, capture the reasoning in a comment; no ongoing manual step is required afterward.
+- [Risk] Adding a regression test for an intentionally-uncovered branch could itself lower coverage or feel artificial → Mitigation: only add a regression test if verification actually finds a gap; otherwise skip it per the proposal's conditional wording.

--- a/openspec/changes/archive/2026-08-10-gate-branch-coverage/proposal.md
+++ b/openspec/changes/archive/2026-08-10-gate-branch-coverage/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+CI enforces `--cov-fail-under=98` on the newest Python leg, and `[tool.coverage.run]` already sets `branch = true`, so the data exists — but nothing confirms the 98% gate is actually reading combined line+branch coverage rather than line coverage alone. An untested `if`/`else` side (a covered line, an uncovered branch) could currently slip through CI undetected.
+
+## What Changes
+
+- Verify (and document, via a code comment or the coverage config itself) that `--cov-fail-under=98` reflects combined line+branch coverage under `branch = true`, since `coverage.py` folds branch results into a single overall percentage rather than reporting them as a separate gate.
+- If verification shows branches are *not* actually being enforced, add an explicit check (e.g. `coverage report --fail-under=98` reasoned about branch data, or a `fail_under` setting under `[tool.coverage.report]`) so a regression in branch coverage fails CI the same way a line-coverage regression does.
+- Add a regression test that exercises both sides of a previously branch-uncovered conditional, if the verification step finds a real gap, so the fix is provable rather than just asserted.
+
+## Capabilities
+
+### New Capabilities
+- `branch-coverage-gate`: CI enforcement that a pull request's combined line+branch test coverage does not regress below the configured threshold (currently 98%).
+
+### Modified Capabilities
+(none — no existing specs cover coverage enforcement)
+
+## Impact
+
+- `pyproject.toml` — `[tool.coverage.report]` / `[tool.pytest.ini_options]` `addopts`, if a config-only change is needed.
+- `.github/workflows/check.yml` — the "Enforce coverage threshold" step, if the invocation needs to change.
+- No production code or public API impact; test-and-CI-only change.

--- a/openspec/changes/archive/2026-08-10-gate-branch-coverage/specs/branch-coverage-gate/spec.md
+++ b/openspec/changes/archive/2026-08-10-gate-branch-coverage/specs/branch-coverage-gate/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Combined line and branch coverage enforcement
+CI SHALL fail the build when combined line-and-branch test coverage of the `snakestream` package falls below the configured threshold (98%), not merely when line coverage alone falls below that threshold.
+
+#### Scenario: Fully-covered conditional passes
+- **WHEN** a conditional branch (e.g. an `if`/`else`) has both sides exercised by the test suite
+- **THEN** the coverage gate does not penalize that conditional and the build passes if overall coverage meets the threshold
+
+#### Scenario: Partially-covered conditional fails the gate
+- **WHEN** a conditional branch has only one side exercised by the test suite, dropping combined coverage below 98%
+- **THEN** `uv run pytest --cov-fail-under=98` (or the equivalent `coverage.py` invocation) fails the build
+
+### Requirement: Enforcement scope documented
+The coverage gate's enforcement mechanism SHALL be documented at its point of configuration so future contributors do not need to re-derive whether branch data is included in the gate.
+
+#### Scenario: Reviewing the coverage configuration
+- **WHEN** a contributor reads `[tool.coverage.run]` / `[tool.coverage.report]` in `pyproject.toml`
+- **THEN** a comment or the config itself makes clear that `branch = true` combined with the enforced threshold constitutes a combined line+branch gate

--- a/openspec/changes/archive/2026-08-10-gate-branch-coverage/tasks.md
+++ b/openspec/changes/archive/2026-08-10-gate-branch-coverage/tasks.md
@@ -1,0 +1,22 @@
+## 1. Verify current enforcement behavior
+
+- [x] 1.1 Locally introduce a scratch conditional (e.g. temporarily edit a function to add an `if`/`else` where only one branch is exercised by existing tests) and run `uv run coverage report` / `uv run pytest --cov-fail-under=98` to observe whether the missing branch drops the reported percentage and fails the gate.
+- [x] 1.2 Revert the scratch conditional; record the finding (gate already combined vs. gate is line-only).
+
+## 2. Close the gap (only if verification finds line-only enforcement)
+
+Not applicable — verification (1.1) confirmed the gate is already combined; no code changes made.
+
+- [x] 2.1 ~~Replace or supplement the `--cov-fail-under=98` CLI flag with `[tool.coverage.report] fail_under = 98`~~ — skipped, not needed.
+- [x] 2.2 ~~Update `.github/workflows/check.yml`'s "Enforce coverage threshold" step~~ — skipped, not needed.
+- [x] 2.3 ~~Add a regression test exercising the previously-uncovered branch~~ — skipped, not needed.
+
+## 3. Document the outcome
+
+- [x] 3.1 Add a short comment next to `[tool.coverage.run] branch = true` in `pyproject.toml` stating that the enforced `fail_under`/`--cov-fail-under` threshold reflects combined line+branch coverage.
+- [x] 3.2 Update `roadmap.md`: move this item from **Now** to **Done** with a one-line summary of the finding and any change made.
+
+## 4. Validate
+
+- [x] 4.1 Run `uv run pytest --cov-fail-under=98` locally and confirm it passes on the current (non-scratch) codebase.
+- [x] 4.2 Run `uv run ruff check .` and `uv run ruff format --check .` if `pyproject.toml` was edited.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/branch-coverage-gate/spec.md
+++ b/openspec/specs/branch-coverage-gate/spec.md
@@ -1,0 +1,23 @@
+## Purpose
+
+CI enforcement that a pull request's combined line+branch test coverage of the `snakestream` package does not regress below the configured threshold (currently 98%), so an untested side of a conditional cannot slip through undetected.
+
+## Requirements
+
+### Requirement: Combined line and branch coverage enforcement
+CI SHALL fail the build when combined line-and-branch test coverage of the `snakestream` package falls below the configured threshold (98%), not merely when line coverage alone falls below that threshold.
+
+#### Scenario: Fully-covered conditional passes
+- **WHEN** a conditional branch (e.g. an `if`/`else`) has both sides exercised by the test suite
+- **THEN** the coverage gate does not penalize that conditional and the build passes if overall coverage meets the threshold
+
+#### Scenario: Partially-covered conditional fails the gate
+- **WHEN** a conditional branch has only one side exercised by the test suite, dropping combined coverage below 98%
+- **THEN** `uv run pytest --cov-fail-under=98` (or the equivalent `coverage.py` invocation) fails the build
+
+### Requirement: Enforcement scope documented
+The coverage gate's enforcement mechanism SHALL be documented at its point of configuration so future contributors do not need to re-derive whether branch data is included in the gate.
+
+#### Scenario: Reviewing the coverage configuration
+- **WHEN** a contributor reads `[tool.coverage.run]` / `[tool.coverage.report]` in `pyproject.toml`
+- **THEN** a comment or the config itself makes clear that `branch = true` combined with the enforced threshold constitutes a combined line+branch gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ norecursedirs = ["dist", "build", ".tox", ".virtualenv"]
 testpaths = ["tests"]
 
 [tool.coverage.run]
+# branch = true folds branch-arc coverage into the same "percent covered"
+# figure as line coverage, so CI's --cov-fail-under=98 (see check.yml)
+# already gates on combined line+branch coverage, not line coverage alone.
 branch = true
 source = ["snakestream"]
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,7 +10,6 @@ Small, low-risk, high-confidence — no public API impact.
 
 | Item | Why now |
 |---|---|
-| **Gate branch coverage, not just line coverage** — `--cov-fail-under=98` checks combined coverage; confirm it's actually reading line+branch together, or add an explicit branch-coverage gate. `.coveragerc` already has `branch = true`, so the data exists, it's just not separately enforced. | Config-only change; closes a blind spot the line-coverage gate can hide (an untested `if`/`else` side). |
 | **Add `mypy` (or `pyright`) to CI** | Codebase is fully type-hinted already; nothing currently checks that the hints stay true. Cheap to add, catches drift immediately. |
 | **Add an install/import smoke test across the Python matrix** — `pip install .` + bare `import snakestream` on each of 3.10–3.14, not just running pytest against checked-out source. | A packaging mistake could pass CI today while breaking real installs. Low effort, closes a real gap. |
 
@@ -36,6 +35,12 @@ core semantic.
 
 ## Done
 
+- Verified `--cov-fail-under=98` already enforces combined line+branch
+  coverage, not line coverage alone: `[tool.coverage.run] branch = true`
+  folds branch-arc misses into the same "percent covered" figure the gate
+  reads, confirmed by observing a deliberately partial branch drop the
+  reported percentage. No code change needed; added a comment in
+  `pyproject.toml` recording the finding so it doesn't need re-deriving.
 - `min()`/`max()` used to silently skip falsy candidate values (`0`, `""`,
   `False`) because of a truthiness check in `Stream._min_max`. Fixed by
   replacing the `None`-as-sentinel logic with a proper `_UNSET` sentinel.


### PR DESCRIPTION
CI's --cov-fail-under=98 already enforces combined line+branch coverage via coverage.py's branch = true, verified by observing a deliberately partial branch drop the reported percentage. No code change needed; documented the finding in pyproject.toml and moved the roadmap item to Done. Adds the openspec change history and the new branch-coverage-gate capability spec.