### PR TITLE
ci: add ty static type checking, archive openspec change

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,13 @@ jobs:
     - name: Test with pytest
       run: uv run pytest
 
+    # Type-checking results don't meaningfully vary across CPython versions
+    # the way branch-coverage measurement does, so only run it once on the
+    # newest matrix version instead of redundantly on every job.
+    - name: Type check with ty
+      if: matrix.python-version == '3.14'
+      run: uv run ty check src
+
     # Vulnerability data doesn't vary by interpreter version, so only
     # audit once on the newest matrix version instead of redundantly
     # hitting the advisory database from every job.

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __pycache__/*
 .settings
 .idea
 .vscode
+.claude
 tags
 
 # Package files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ uv run pytest --cov-fail-under=98          # enforce coverage threshold (as CI d
 uv run ruff check .                        # lint
 uv run ruff format --check .               # verify formatting
 uv run ruff format .                       # apply formatting
+uv run ty check src                        # static type check
 uv run --with pip-audit pip-audit          # dependency vulnerability audit
 ```
 
-CI (`.github/workflows/check.yml`) runs the ruff checks, `uv run pytest`, `pip-audit` and the coverage gate across Python 3.10–3.14; `pip-audit` and the coverage gate only run on the 3.14 leg. Match that when validating changes.
+CI (`.github/workflows/check.yml`) runs the ruff checks, `uv run pytest`, `ty`, `pip-audit` and the coverage gate across Python 3.10–3.14; `ty`, `pip-audit`, and the coverage gate only run on the 3.14 leg. Match that when validating changes.
 
 ## Architecture
 

--- a/openspec/changes/archive/2026-08-10-add-type-checking-ci/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-add-type-checking-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-add-type-checking-ci/design.md
+++ b/openspec/changes/archive/2026-08-10-add-type-checking-ci/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`src/snakestream` is fully type-hinted (`type.py` defines `Predicate`, `Mapper`, `FlatMapper`, `Comparator`, `Consumer`, `Accumulator`, `CloseHandler` as `Union[sync, Awaitable[...]]`-style aliases used throughout `stream.py`, `base_stream.py`, `parallel_stream.py`), but no CI step currently verifies the hints are correct — only `ruff` (lint/format) and `pytest` run today. CI (`.github/workflows/check.yml`) already matrices across Python 3.10–3.14 via `uv`, and the project already depends on Astral's `ruff` and `uv`, making Astral's `ty` a natural first candidate to try before falling back to the more established `mypy`/`pyright`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pick one type checker (`ty` if it handles this codebase well, else `mypy` or `pyright`) and gate CI on it.
+- Keep the gate green from the moment it's added — no starting in a known-failing state.
+- Minimize config: reuse the existing `code_check` job rather than adding a new matrix/job.
+
+**Non-Goals:**
+- Chasing 100% strictness immediately (e.g. `--strict` mypy mode) — start with defaults and tighten later if desired.
+- Type-checking `tests/` — scope is `src/snakestream` only, matching the coverage config's `source = ["snakestream"]`.
+- Running the type checker across the full 3.10–3.14 matrix — one representative Python version is enough, mirroring how the coverage gate is only enforced on 3.14.
+
+## Decisions
+
+- **Try `ty` first**: it's Rust-based (fast, matching `ruff`'s speed profile), from the same vendor already in the toolchain (`uv`, `ruff`), and actively developed. Alternative considered: default straight to `mypy` (most mature, widest community usage, but slower and more config-heavy) or `pyright` (mature, fast, but Node/npm-based tooling that doesn't fit the `uv`-only dev workflow as cleanly). Decision: spend a short, bounded evaluation on `ty`; fall back to `mypy` if it chokes on this codebase's `Awaitable`-union type aliases or the `TYPE_CHECKING`-guarded import in `stream.py`.
+- **Add as a `uv run --with` step, not a permanent dev dependency, until proven**: run `uv run --with ty ty check src` during evaluation (same pattern already used for `pip-audit` in CI) to avoid committing to a dependency before confirming it works. Once validated, promote it to `[dependency-groups] dev` in `pyproject.toml` for local use (`uv run ty check`) and pin the CI step accordingly.
+- **Single CI leg, not full matrix**: add the type-check step gated to one Python version (align with the existing `if matrix.python-version == '3.14'` pattern used for `pip-audit` and the coverage gate), since type-checking results don't meaningfully vary across CPython versions the way branch-coverage measurement does.
+- **Fix real errors, don't suppress broadly**: if the chosen checker finds genuine type drift, fix it inline as part of this change rather than blanket-ignoring, so the gate is meaningful from day one. Scoped per-line ignores (with a comment explaining why) are acceptable for rare, justified cases (e.g. known checker limitations with the codebase's `Awaitable`-typing pattern).
+
+## Risks / Trade-offs
+
+- [Risk] `ty` is newer and may have rough edges with `Awaitable`/`Union` heavy code in `type.py`, or with the `TYPE_CHECKING`-guarded `StreamBuilder` import → Mitigation: bounded local evaluation before committing; fall back to `mypy` if `ty` produces excessive false positives or crashes.
+- [Risk] Adding a new gate could surface a backlog of real type errors, expanding scope beyond "add a checker" → Mitigation: fix straightforward errors as part of this change; if the backlog is large, scope this change down to a minimal passing baseline and file follow-up items rather than blocking the whole change.
+- [Risk] Single-Python-version enforcement could miss version-specific typing differences (e.g. `typing` module changes across 3.10–3.14) → Mitigation: acceptable trade-off consistent with the existing coverage-gate precedent; revisit if it causes a real miss.

--- a/openspec/changes/archive/2026-08-10-add-type-checking-ci/proposal.md
+++ b/openspec/changes/archive/2026-08-10-add-type-checking-ci/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The codebase is fully type-hinted, but nothing in CI actually checks that the hints stay accurate — type errors can drift in silently. `ty`, Astral's newer Rust-based type checker, is worth trying alongside the more established `mypy`/`pyright` options given the project already uses Astral's `ruff` and `uv` toolchain.
+
+## What Changes
+
+- Evaluate `ty` against the codebase locally: run it, review the findings, and judge signal quality (false positives, coverage of the `async`/`await`-heavy, `Awaitable`-typed code in `type.py`).
+- If `ty` proves workable, add it as a dev dependency and wire it into CI (`.github/workflows/check.yml`) as a new step, matching the existing pattern of dependency groups in `pyproject.toml`.
+- If `ty` finds real type errors in the current codebase, fix them as part of adding the gate (small, type-only fixes) or, if fixes are non-trivial, suppress with justified inline ignores and note them for follow-up — do not merge a gate that starts red.
+- If `ty` proves immature or unworkable for this codebase (e.g. can't handle the `Awaitable`-union aliases in `type.py`, or the `TYPE_CHECKING`-guarded import in `stream.py`), fall back to `mypy` or `pyright` instead — the roadmap item is "add a type checker," not "add `ty` specifically."
+
+## Capabilities
+
+### New Capabilities
+- `static-type-checking`: CI enforcement that type hints across `src/snakestream` remain internally consistent, checked by a static type checker on every push.
+
+### Modified Capabilities
+(none — no existing specs cover type checking)
+
+## Impact
+
+- `pyproject.toml` — new `[dependency-groups] dev` entry for the chosen type checker; possibly new `[tool.ty]` (or `[tool.mypy]`/`[tool.pyright]`) config section.
+- `.github/workflows/check.yml` — new "Type check" step in the `code_check` job.
+- Possibly `src/snakestream/*.py` — small type-hint fixes if the checker surfaces real drift.
+- No runtime/public API impact; dev-tooling and CI-only change.

--- a/openspec/changes/archive/2026-08-10-add-type-checking-ci/specs/static-type-checking/spec.md
+++ b/openspec/changes/archive/2026-08-10-add-type-checking-ci/specs/static-type-checking/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: CI enforces static type correctness
+CI SHALL run a static type checker against `src/snakestream` on at least one Python version in the build matrix and SHALL fail the build when the checker reports type errors.
+
+#### Scenario: Type-consistent code passes
+- **WHEN** all type hints in `src/snakestream` are internally consistent with how they're used
+- **THEN** the type-check CI step passes
+
+#### Scenario: Type error fails the gate
+- **WHEN** a change introduces a type inconsistency (e.g. a function returns a type that violates its declared return annotation)
+- **THEN** the type-check CI step fails the build
+
+### Requirement: Type checker selection is evaluated, not assumed
+The type checker used for enforcement SHALL be chosen based on a local evaluation against this codebase's `async`/`await`-heavy, `Awaitable`-typed code, not assumed to work without verification.
+
+#### Scenario: Evaluated checker handles the codebase's typing patterns
+- **WHEN** the chosen checker runs against `src/snakestream`, including the `Awaitable`-union aliases in `type.py` and the `TYPE_CHECKING`-guarded import in `stream.py`
+- **THEN** it produces accurate results without excessive false positives or crashes
+
+#### Scenario: Checker proves unworkable and a fallback is used
+- **WHEN** the initially-evaluated checker (`ty`) cannot handle the codebase's typing patterns
+- **THEN** an established alternative (`mypy` or `pyright`) is used instead, and the reasoning is recorded

--- a/openspec/changes/archive/2026-08-10-add-type-checking-ci/tasks.md
+++ b/openspec/changes/archive/2026-08-10-add-type-checking-ci/tasks.md
@@ -1,0 +1,24 @@
+## 1. Evaluate `ty`
+
+- [x] 1.1 Run `uv run --with ty ty check src` locally against the current codebase and review the output.
+- [x] 1.2 Assess whether `ty` handles the `Awaitable`-union type aliases in `type.py` and the `TYPE_CHECKING`-guarded import in `stream.py` without excessive false positives or crashes.
+- [x] 1.3 Decide: proceed with `ty`, or fall back to `mypy`/`pyright` if `ty` proves unworkable. Record the decision.
+
+## 2. Fix or triage findings
+
+- [x] 2.1 Fix genuine type errors surfaced by the checker in `src/snakestream`.
+- [x] 2.2 For any finding that's a checker limitation rather than a real bug, add a scoped inline ignore with a comment explaining why.
+- [x] 2.3 Confirm the checker runs clean (zero errors) against `src/snakestream` after fixes.
+
+## 3. Wire into the project
+
+- [x] 3.1 Add the chosen checker to `[dependency-groups] dev` in `pyproject.toml`.
+- [x] 3.2 Add any needed config section (e.g. `[tool.ty]`, `[tool.mypy]`, or `[tool.pyright]`) to `pyproject.toml` — not needed, `ty` runs clean with defaults.
+- [x] 3.3 Add a "Type check" step to the `code_check` job in `.github/workflows/check.yml`, gated to a single Python version (matching the `if matrix.python-version == '3.14'` pattern used for `pip-audit` and the coverage gate).
+
+## 4. Document and validate
+
+- [x] 4.1 Update `CLAUDE.md`'s command reference to include the new local type-check command.
+- [x] 4.2 Update `roadmap.md`: move this item from **Now** to **Done**, noting which checker was chosen and why.
+- [x] 4.3 Run the new type-check command locally and confirm it passes.
+- [x] 4.4 Run `uv run pytest`, `uv run ruff check .`, and `uv run ruff format --check .` to confirm no regressions from any code changes made while fixing type errors.

--- a/openspec/specs/static-type-checking/spec.md
+++ b/openspec/specs/static-type-checking/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+CI enforcement that type hints across `src/snakestream` remain internally consistent, checked by a static type checker on every push, with the checker itself chosen by evaluating it against this codebase's `async`/`await`-heavy, `Awaitable`-typed code rather than assumed to work.
+
+## Requirements
+
+### Requirement: CI enforces static type correctness
+CI SHALL run a static type checker against `src/snakestream` on at least one Python version in the build matrix and SHALL fail the build when the checker reports type errors.
+
+#### Scenario: Type-consistent code passes
+- **WHEN** all type hints in `src/snakestream` are internally consistent with how they're used
+- **THEN** the type-check CI step passes
+
+#### Scenario: Type error fails the gate
+- **WHEN** a change introduces a type inconsistency (e.g. a function returns a type that violates its declared return annotation)
+- **THEN** the type-check CI step fails the build
+
+### Requirement: Type checker selection is evaluated, not assumed
+The type checker used for enforcement SHALL be chosen based on a local evaluation against this codebase's `async`/`await`-heavy, `Awaitable`-typed code, not assumed to work without verification.
+
+#### Scenario: Evaluated checker handles the codebase's typing patterns
+- **WHEN** the chosen checker runs against `src/snakestream`, including the `Awaitable`-union aliases in `type.py` and the `TYPE_CHECKING`-guarded import in `stream.py`
+- **THEN** it produces accurate results without excessive false positives or crashes
+
+#### Scenario: Checker proves unworkable and a fallback is used
+- **WHEN** the initially-evaluated checker (`ty`) cannot handle the codebase's typing patterns
+- **THEN** an established alternative (`mypy` or `pyright`) is used instead, and the reasoning is recorded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest-asyncio",
     "pytest-mock",
     "ruff",
+    "ty",
 ]
 
 [tool.pytest.ini_options]

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,7 +10,6 @@ Small, low-risk, high-confidence — no public API impact.
 
 | Item | Why now |
 |---|---|
-| **Add `mypy` (or `pyright`) to CI** | Codebase is fully type-hinted already; nothing currently checks that the hints stay true. Cheap to add, catches drift immediately. |
 | **Add an install/import smoke test across the Python matrix** — `pip install .` + bare `import snakestream` on each of 3.10–3.14, not just running pytest against checked-out source. | A packaging mistake could pass CI today while breaking real installs. Low effort, closes a real gap. |
 
 ## Next
@@ -35,6 +34,16 @@ core semantic.
 
 ## Done
 
+- Added static type checking to CI using `ty`, Astral's newer Rust-based
+  type checker — chosen over `mypy`/`pyright` since it fit the existing
+  `uv`/`ruff` toolchain and handled the codebase's `Awaitable`-union type
+  aliases without issue. Fixed the 6 genuine type errors it surfaced
+  (`BaseStream.on_close`'s return type, `ParallelStream`'s task-list
+  typing, `StreamBuilder`'s unbound `TypeVar`, `Stream.collect`'s generic
+  return type, and `Stream._min_max`'s sentinel-return typing), plus one
+  scoped `ty: ignore` for a case the checker can't narrow via the
+  runtime `iscoroutinefunction()` check in `Stream.sorted`. Gated to the
+  3.14 matrix leg only, matching the coverage-gate precedent.
 - Verified `--cov-fail-under=98` already enforces combined line+branch
   coverage, not line coverage alone: `[tool.coverage.run] branch = true`
   folds branch-arc misses into the same "percent covered" figure the gate

--- a/src/snakestream/base_stream.py
+++ b/src/snakestream/base_stream.py
@@ -55,7 +55,7 @@ class BaseStream:
         new_source = self._compose()
         return ParallelStream(new_source, self._close_handlers)
 
-    def on_close(self, close_handler: CloseHandler) -> Stream:
+    def on_close(self, close_handler: CloseHandler) -> BaseStream:
         self._close_handlers.append(close_handler)
         return self
 

--- a/src/snakestream/parallel_stream.py
+++ b/src/snakestream/parallel_stream.py
@@ -19,17 +19,17 @@ class ParallelStream(Stream):
         self, intermediaries: list[Callable], iterable: AsyncGenerator, processes: int = PROCESSES
     ) -> AsyncGenerator:
         async_iterators = [self._sequential(intermediaries[:], iterable) for n in range(processes)]
-        tasks = [asyncio.ensure_future(n.__anext__()) for n in async_iterators]
+        tasks: list[asyncio.Task[Any] | None] = [asyncio.ensure_future(n.__anext__()) for n in async_iterators]
 
         try:
             while any([n is not None for n in tasks]):
-                waitlist = filter(lambda n: n is not None, tasks)
+                waitlist: list[asyncio.Task[Any]] = [t for t in tasks if t is not None]
                 done, _ = await asyncio.wait(waitlist, return_when=asyncio.FIRST_COMPLETED)
 
                 for task in done:
                     task_idx = tasks.index(task)
                     try:
-                        result = tasks[task_idx].result()
+                        result = task.result()
                         tasks[task_idx] = asyncio.ensure_future(async_iterators[task_idx].__anext__())
                         yield result
                     except StopAsyncIteration:

--- a/src/snakestream/stream.py
+++ b/src/snakestream/stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import cmp_to_key
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from collections.abc import AsyncGenerator, Callable, Generator
 
 from snakestream.base_stream import BaseStream
@@ -130,7 +130,10 @@ class Stream(BaseStream):
                 if iscoroutinefunction(comparator):
                     cache = await merge_sort(cache, comparator)
                 else:
-                    cache.sort(key=cmp_to_key(comparator))
+                    # ty can't narrow `comparator`'s type via the runtime
+                    # iscoroutinefunction() check above; this branch only
+                    # runs for the sync `bool`-returning half of the union.
+                    cache.sort(key=cmp_to_key(comparator))  # ty: ignore[invalid-argument-type]
             else:
                 cache.sort()
             # unblock the stream
@@ -186,7 +189,7 @@ class Stream(BaseStream):
         return self
 
     # Terminals
-    def collect(self, collector: Callable) -> list | AsyncGenerator:
+    def collect(self, collector: Callable[[AsyncGenerator], R]) -> R:
         return collector(self._compose())
 
     async def reduce(self, identity: T | R, accumulator: Accumulator) -> T | R:
@@ -246,7 +249,7 @@ class Stream(BaseStream):
             else:
                 if comparator(n, found):
                     found = n
-        return None if found is _UNSET else found
+        return None if found is _UNSET else cast(T, found)
 
     async def all_match(self, predicate: Predicate) -> bool:
         async for n in self._compose():

--- a/src/snakestream/stream_builder.py
+++ b/src/snakestream/stream_builder.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from typing import Generic
+
 from snakestream.stream import Stream
 from snakestream.type import T
 
 
-class StreamBuilder:
+class StreamBuilder(Generic[T]):
     def __init__(self) -> None:
         self._elements: list[T] = []
 
-    def add(self, element: T) -> StreamBuilder:
+    def add(self, element: T) -> StreamBuilder[T]:
         self.accept(element)
         return self
 

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -306,6 +307,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [[package]]
@@ -360,6 +362,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.69"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5b/7a618632dfe9373b7df572ecd7a08c8f799d772fbc317da82dd3aa363207/ty-0.0.69.tar.gz", hash = "sha256:b65106e9ff24fa76e25e1142fb09c85244e815c40450e3021d2bf652c231bb43", size = 6565094, upload-time = "2026-08-06T10:04:25.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/60/6534092f4d2c15e2491807edd609c2e50d527c1fed957acf40b9f110b64a/ty-0.0.69-py3-none-linux_armv6l.whl", hash = "sha256:98bfd383b273540829af673e7f98b9c1c4bcc8547d12a1a3806cd0bec7f0e087", size = 12364185, upload-time = "2026-08-06T10:03:47.137Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2b/5c29689bd4f74c2e3394d983d85e4011b629f2ce3730c9442553b8554bf8/ty-0.0.69-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:964621ddd05771660017c51b4e74078d861d9fc863c21ef2a500db1ab62c9ccf", size = 12042510, upload-time = "2026-08-06T10:03:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/09/46/fa085bde4d23516d7ef14b24736fc5dd7dc498f60f52b3d077e59ffdea20/ty-0.0.69-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ffea4048dd0da4c9c97393b4be0901098a9065b06fa81be2477cbde65d8a151", size = 11549397, upload-time = "2026-08-06T10:03:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/97b9efb2061dcab6fef1e94a4ad99df0bb45bd2cc15d4f5794c787ee0552/ty-0.0.69-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8684d4a70aadd1eab0f41bdba835e3288ef49db8402a8e6ca81bab52ed5d610", size = 12115567, upload-time = "2026-08-06T10:03:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c1/a5e0404965093835f3e62544e661784ec0aa8ef0b006ed50af50b19c107e/ty-0.0.69-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:afaaba240ab4122e2069a796836d10be81b4ddb053ae268b3dff962a0b4ca5c7", size = 12149770, upload-time = "2026-08-06T10:03:55.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/39/8cad6b205a4abe8a044ca0c84aea71e8ccda29b07a75a5f090e310605580/ty-0.0.69-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11ea63ef07d4e33aeb1a775cf5f2c736b3ed22fa6f8b1b608591612c36795044", size = 12941278, upload-time = "2026-08-06T10:03:58.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/8766d96b732c2a060d70dc8ccafcc4d6a54109a2a95f1deb0705de88892b/ty-0.0.69-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb3730b1268e92a2907d7aea3afe8dd1b360ae65862f0557080cf479d481b424", size = 13426509, upload-time = "2026-08-06T10:04:00.621Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1f/e991b2cde953ea5b94d6a9a4c45c87937bd916bc09235f764407bf471c0a/ty-0.0.69-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a544ff57a752ef186ed40b5a2f44c17402af4cdefeb74a311ca02ebd57c4fca0", size = 13106582, upload-time = "2026-08-06T10:04:02.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/bb/73538f1b99e3558fd9db87b98698426f0f60fc8666da0b1efd0e70e275eb/ty-0.0.69-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87ed2cbca20caddfdf8e3e14d213ce91b67e75feed78900f4aaf3ef884954028", size = 12708931, upload-time = "2026-08-06T10:04:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cd/484a5208d74c4ad1155933906295ccdce9aa81a257d8df2ab9e41bd60133/ty-0.0.69-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2684efcbce5b6fe45045faf610b377b50781b6d2aa7e61ea23ecf5b3d2bce421", size = 12985322, upload-time = "2026-08-06T10:04:07.587Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/81/b75003f0d4da9ab3bc8fd4f4802f836cb9921ff7e70f460604f7b769a0b5/ty-0.0.69-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:da9aeb26fdac1d2214937542b59e0d4d1ba94ec7a3f45444f33c846de1eb1d63", size = 12063910, upload-time = "2026-08-06T10:04:09.835Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/088469f547ef63dceefc4a75826aedee5014f9371dc5171cde931896a82c/ty-0.0.69-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:00e7677cd14ede381f705f71104ea7b8ea0ce217a8634e19a89781953de0e9ad", size = 12166823, upload-time = "2026-08-06T10:04:12.114Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c9/ce88a0bec0d46d8ae180b99c6ec014866fecc4cba1727b5feec8877b2765/ty-0.0.69-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d91965eb799649833d0d6042db09cd03d15289125245337cc46a2606effb7bda", size = 12483136, upload-time = "2026-08-06T10:04:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9e/6fae0ff225a0012642cf72c077e20f8f448c0a80771bc3360e8178fe2f32/ty-0.0.69-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f03359cd8e5c412aa0c181118fa9b9061a4dddaedbb61bac0a424fb0814d402", size = 12799025, upload-time = "2026-08-06T10:04:16.445Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/43/78a658d18b2a4ccf35b053392f2213bf12e3c63b2abea512d3b6751d1f4c/ty-0.0.69-py3-none-win32.whl", hash = "sha256:ec460e01586b1eb91894c4a8403bee3e045a47e7a4ada943cc27ce8e348e88cf", size = 11787774, upload-time = "2026-08-06T10:04:18.622Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/88db1f674403f2b81316a853a44a81ed220621fa96f8f7ae586fb6ca7513/ty-0.0.69-py3-none-win_amd64.whl", hash = "sha256:18976ca26a4e28fc3249477f79a695d5502e670803f2e080d89ac905baef3c6e", size = 12864038, upload-time = "2026-08-06T10:04:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/7b/6fc6efd00c69103d70f2bdbe824343089cd70b17b3079170057d3e5a3ac0/ty-0.0.69-py3-none-win_arm64.whl", hash = "sha256:7d4ca3bb74d91cb9947ba3f3b4cb131ad6a2b3ecc76d34040c4ec6092d2e411d", size = 12196693, upload-time = "2026-08-06T10:04:22.902Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Evaluated ty (Astral's Rust-based type checker) against the codebase; it handled the Awaitable-union type patterns cleanly, so no fallback to mypy/pyright was needed. Fixed the 6 genuine type errors it surfaced across base_stream.py, parallel_stream.py, stream.py, and stream_builder.py, and added one justified ty: ignore for a case the checker can't narrow via the runtime iscoroutinefunction() check. Wired into CI on the 3.14 leg only, matching the coverage/pip-audit gate pattern. Also ignores .claude/ (local harness config).