### PR TITLE
fix: reject bool-returning comparators at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ In snakestream this has been omitted since python has generators and those can b
 
 ## Migration
 These are a list of the known breaking changes. Until release 1.0.0 focus will be on implementing features and changing things that does not align with how streams work in java.
+- **0.3.5 -> next:** `sorted()`/`min()`/`max()` now raise `TypeError` if the supplied comparator returns `bool` instead of `int`. Python's `bool` is a subclass of `int`, so a bool-returning comparator (e.g. `lambda x, y: x > y`) previously satisfied the `Comparator` type silently while violating its 3-way sign contract. Callers must switch to an int-returning comparator (e.g. `lambda x, y: x - y`).
 - **0.3.5 -> next:** `min()`/`max()` now require a Java-style 3-way comparator (negative/zero/positive int, matching `sorted()`), not a bool. Callers passing a bool-returning comparator (e.g. `lambda x, y: x > y`) must switch to one returning an int (e.g. `lambda x, y: x - y`) or their result will silently be wrong. This also fixes `min()`'s previous last-wins tie-break so it now keeps the first of equal elements, matching `max()`.
 - **0.2.4 -> 0.3.0:** `stream_of()` has been removed in favour of `Stream.of()` for getting closer to the java api.
 - **0.1.0 -> 0.2.0:** The `unique()` function has been renamed `distinct()`. So rename all imports of that function, and it should be OK

--- a/openspec/changes/reject-bool-comparator/.openspec.yaml
+++ b/openspec/changes/reject-bool-comparator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/reject-bool-comparator/design.md
+++ b/openspec/changes/reject-bool-comparator/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`_min_max()` and `sorted()` (`stream.py`) both already compute a `sign`/comparison result from the user-supplied `Comparator` and branch on it — `_min_max` does `if (sign > 0) == keep_positive and sign != 0`, `sorted()`'s sync branch feeds the comparator to `cmp_to_key`, and its async branch (`sort.py`) does `await comparator(left[i], right[j]) <= 0`. None of these currently distinguish an `int` result from a `bool` result, because `bool` is a subclass of `int` in Python and both `>`/`<=` comparisons against `0` work the same either way — a bool comparator just happens to never produce a negative value, so `min()`/`sorted()` degrade silently instead of erroring. This gap survives even after the `comparator-contract` fix (commit `4f526bb`) because that fix corrected the *interpretation* of the sign, not whether a bool sneaking in gets caught.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fail fast and loudly (`TypeError`) the first time a comparator returns a literal `bool`, in all three comparator-consuming operations (`sorted()`, `min()`, `max()`), sync and async comparators alike.
+- Keep the check cheap — one `isinstance` per comparator invocation, no behavior change for correctly-typed `int` comparators.
+- Fix the two existing tests that were silently relying on this class of bug.
+
+**Non-Goals:**
+- Not attempting a static-typing fix (a `Protocol` or stricter alias) — established in conversation that Python's `bool <: int` subtyping makes this structurally impossible to catch statically.
+- Not validating the *magnitude* or transitivity of the comparator's results (e.g. detecting a non-total-order comparator) — only the bool-vs-int class of mistake, which is the one that silently degrades today.
+- Not changing `_min_max`'s or `sorted()`'s existing sign-interpretation logic, only adding a guard in front of it.
+
+## Decisions
+
+- **Where to check**: at the single point each function already extracts the comparator's return value (`_min_max`'s `sign = ...`/`await ...`, and `sorted()`'s sync `cmp_to_key(comparator)` path and the async `merge_sort`/`_merge` comparator call in `sort.py`). Centralizing isn't possible without a shared helper since sync/async and the three call sites differ; instead add a tiny local guard `_reject_bool(sign)` (or inline `isinstance` check) reused at each of the ~3-4 call sites.
+  - Alternative considered: wrap the user's comparator once at entry (`min()`/`max()`/`sorted()`) in a checking adapter that both awaits-if-needed and validates. Rejected for now as a larger refactor than this fix needs; noted as a possible follow-up if the duplication across call sites becomes annoying.
+- **Check uses `isinstance(sign, bool)`, not `type(sign) is bool`**: `isinstance` correctly catches `True`/`False` (including any bool-returning expression) while never misfiring on plain `int` results, since no other builtin subclasses `bool`.
+- **Error type**: `TypeError`, matching Python convention for "wrong type passed by caller" and consistent with how `ty`/mypy would have flagged this if the language allowed it.
+- **Message content**: name the offending function (`min`/`max`/`sorted`) and state the expected contract ("comparator must return a 3-way int: negative, zero, or positive — not bool") so the error is actionable without needing to read `comparator-contract`'s spec.
+- **Sync/async parity**: the guard runs identically after `await`-ing an async comparator or calling a sync one — same check, same message, since `sign`'s value is what's being validated, not how it was obtained.
+
+## Risks / Trade-offs
+
+- [Any caller currently passing a bool comparator to `min()`/`max()`/`sorted()` — even one that "happened to work" like the two existing tests — now gets a hard failure instead of a silent (possibly correct-by-luck) result] → This is the intended outcome; documented as **BREAKING** in README's migration log per `CLAUDE.md`.
+- [Slight per-call overhead from the `isinstance` check on every comparator invocation, including inside `sorted()`'s O(n log n) comparisons] → Negligible (`isinstance` against a single builtin type is a cheap C-level check); no measurable impact expected at the scales this library targets.
+- [Duplication of the same guard across `_min_max` and both branches of `sorted()`'s comparator use] → Accepted per the "Decisions" alternative above; revisit as a shared helper only if a fourth call site appears.
+
+## Migration Plan
+
+1. Add the bool-rejection guard to `Stream._min_max()` (`stream.py`).
+2. Add the same guard to `Stream.sorted()`'s comparator path (`stream.py`) and, if the async merge-sort path in `sort.py` also directly consumes the comparator's raw result, add it there too.
+3. Fix `test_find_min_value_object_comparator` (`tests/test_min.py:91`) and `test_find_max_value_object_comparator` (`tests/test_max.py:91`) to use 3-way comparators.
+4. Add regression tests asserting `TypeError` for bool comparators across `min()`, `max()`, `sorted()`, sync and async.
+5. Update README's migration log and parity notes; move the roadmap item from **Now** to **Done**.
+
+No runtime/deployment migration needed — library-only change.
+
+## Open Questions
+
+None.

--- a/openspec/changes/reject-bool-comparator/proposal.md
+++ b/openspec/changes/reject-bool-comparator/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`Comparator` (`type.py:16`) is typed `Callable[[T, T], int | Awaitable[int]]`, but Python's `bool` is a subclass of `int`, so a bool-returning comparator like `lambda x, y: x.id > y.id` satisfies that type under `ty`/mypy/pyright without ever producing a negative value — silently violating the 3-way sign contract `sorted()`/`min()`/`max()` all depend on (see `openspec/specs/comparator-contract/spec.md`). No static-typing change can catch this, since it's structural to Python (unlike Java, where `Comparator<T>.compare()` must return primitive `int` and a boolean-returning lambda is a compile error). Two existing tests (`test_find_min_value_object_comparator` in `tests/test_min.py:91`, `test_find_max_value_object_comparator` in `tests/test_max.py:91`) already pass a bool comparator and only pass today because the first list element happens to already be the min/max — false positives that don't verify correct behavior.
+
+## What Changes
+
+- Add a runtime guard in `Stream._min_max()` and `Stream.sorted()` that rejects a comparator whose return value is `bool` (`isinstance(sign, bool)`), raising `TypeError` with a message pointing at the 3-way `int` contract.
+- **BREAKING**: any caller currently passing a bool-returning comparator to `min()`, `max()`, or `sorted()` will now get an immediate `TypeError` instead of silently wrong (or accidentally correct) results.
+- Fix `test_find_min_value_object_comparator` (`tests/test_min.py:91`) and `test_find_max_value_object_comparator` (`tests/test_max.py:91`) to use proper 3-way comparators (e.g. `lambda x, y: x.id - y.id`).
+- Fix an additional 16 pre-existing tests across `tests/test_min.py` and `tests/test_max.py` that also pass bool comparators (discovered during implementation — nearly every test in both files predates the 3-way-comparator fix in commit `4f526bb` and was never migrated) to use 3-way `int` comparators instead.
+- Add regression tests asserting `TypeError` is raised for bool comparators passed to `min()`, `max()`, and `sorted()` (sync and async comparator variants).
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `comparator-contract`: adds a requirement that `sorted()`, `min()`, and `max()` actively reject a comparator that returns `bool` at runtime, rather than silently accepting it as if it were a valid 3-way `int` result.
+
+## Impact
+
+- `src/snakestream/stream.py`: `_min_max()` and `sorted()` gain a bool-rejection check on the comparator's return value.
+- `tests/test_min.py`, `tests/test_max.py`, `tests/test_sorted.py` (or equivalent): fix the two false-positive tests; add new tests for the `TypeError` guard.
+- `README.md`: migration log entry per `CLAUDE.md` for the breaking behavior change.
+- `roadmap.md`: move the top **Now** item to **Done** once implemented.

--- a/openspec/changes/reject-bool-comparator/specs/comparator-contract/spec.md
+++ b/openspec/changes/reject-bool-comparator/specs/comparator-contract/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Comparators must not return bool
+`sorted()`, `min()`, and `max()` on `Stream` SHALL raise `TypeError` if a user-supplied `Comparator` returns a value of type `bool`, whether the comparator is sync or `async`. This guards the 3-way `int` contract (defined in "Single 3-way Comparator contract") against Python's `bool <: int` subtyping, which would otherwise let a boolean predicate (e.g. `lambda x, y: x > y`) satisfy the `Comparator` type statically while silently violating its sign semantics (a bool result can never be negative, so "orders before" can never be signaled).
+
+#### Scenario: sorted() rejects a bool comparator
+- **WHEN** `Stream.of([3, 1, 2]).sorted(lambda a, b: a > b)` is collected
+- **THEN** a `TypeError` is raised before any ordering result is returned
+
+#### Scenario: max() rejects a bool comparator
+- **WHEN** `Stream.of([3, 1, 2]).max(lambda a, b: a > b)` is awaited
+- **THEN** a `TypeError` is raised
+
+#### Scenario: min() rejects a bool comparator
+- **WHEN** `Stream.of([3, 1, 2]).min(lambda a, b: a > b)` is awaited
+- **THEN** a `TypeError` is raised
+
+#### Scenario: async bool comparator is rejected identically
+- **WHEN** an `async def` comparator returning `bool` is passed to `sorted()`, `min()`, or `max()`
+- **THEN** a `TypeError` is raised after the comparator is awaited, using the same rejection as the sync case
+
+#### Scenario: a proper 3-way int comparator is unaffected
+- **WHEN** `Stream.of([3, 1, 2]).max(lambda a, b: a - b)` is awaited
+- **THEN** no error is raised and the result is `3`

--- a/openspec/changes/reject-bool-comparator/tasks.md
+++ b/openspec/changes/reject-bool-comparator/tasks.md
@@ -1,0 +1,33 @@
+## 1. Runtime guard
+
+- [x] 1.1 Added `check_comparator_result_type(value)` in `sort.py`: raises `TypeError` (generic message, no op name) if `type(value) is not int` — rejects `bool` since it's a distinct type from `int` under `type() is` even though `isinstance(bool, int)` is true.
+- [x] 1.2 `Stream._min_max()`'s `compare()` helper (`stream.py`) now assigns `sign` on its own line, calls `check_comparator_result_type(sign)`, then returns it.
+- [x] 1.3 `Stream.sorted()`'s sync branch (`stream.py`) wraps `comparator` in a local `checked_comparator` that checks the sign before returning it, passed to `cmp_to_key()`.
+- [x] 1.4 `sort.py`'s `_merge()` (async branch, used by `merge_sort()`) checks the sign on its own line right after `await comparator(...)`.
+
+## 2. Fix false-positive tests
+
+- [x] 2.1 Updated `test_find_min_value_object_comparator` (`tests/test_min.py`) to `lambda x, y: x.id - y.id`.
+- [x] 2.2 Updated `test_find_max_value_object_comparator` (`tests/test_max.py`) to `lambda x, y: x.id - y.id`.
+- [x] 2.3 Updated all 16 additional pre-existing bool-comparator tests in `tests/test_min.py`/`tests/test_max.py` to 3-way `int` comparators (`x - y`, `len(x) - len(y)`).
+- [x] 2.4 Re-ran the updated tests via `uv run pytest tests/test_min.py tests/test_max.py` — all pass with the same expected values as before.
+
+## 3. Regression tests
+
+- [x] 3.1 Added `test_find_min_value_rejects_bool_comparator` (`tests/test_min.py`) asserting `TypeError`.
+- [x] 3.2 Added `test_find_max_value_rejects_bool_comparator` (`tests/test_max.py`) asserting `TypeError`.
+- [x] 3.3 Added `test_sorted_rejects_bool_comparator` (`tests/test_sorted.py`) asserting `TypeError`.
+- [x] 3.4 Added async variants: `test_find_min_value_rejects_async_bool_comparator`, `test_find_max_value_rejects_async_bool_comparator`, `test_sorted_rejects_async_bool_comparator`.
+- [x] 3.5 Already covered by existing `test_find_min_value_three_way_comparator`, `test_find_max_value_three_way_comparator`, and `test_sorted_comparator`/`test_sorted_comparator_matches_cmp_to_key` — all use proper 3-way `int` comparators and continue to pass unaffected.
+
+## 4. Docs
+
+- [x] 4.1 Added a migration log entry to README.md documenting the breaking `TypeError` behavior.
+- [x] 4.2 Moved the item from roadmap.md's **Now** section to **Done**, summarizing what was fixed.
+
+## 5. Verification
+
+- [x] 5.1 `uv run pytest` — 145 passed.
+- [x] 5.2 `uv run ruff check .` and `uv run ruff format --check .` — clean.
+- [x] 5.3 `uv run ty check src` — clean.
+- [x] 5.4 `uv run pytest --cov-fail-under=98` — 100% coverage, gate passed.

--- a/roadmap.md
+++ b/roadmap.md
@@ -46,6 +46,23 @@ core semantic.
 
 ## Done
 
+- Added a `check_comparator_result_type()` runtime guard (`sort.py`) that
+  raises `TypeError` if a user-supplied `Comparator` returns `bool` instead
+  of `int`, used by `Stream._min_max()` (backing `min()`/`max()`) and both
+  branches of `Stream.sorted()` (sync `cmp_to_key` path and the async
+  `merge_sort`/`_merge` path). Closes a gap the earlier `Comparator`
+  contract fix (below) didn't cover: Python's `bool` is a subclass of `int`,
+  so a bool-returning comparator like `lambda x, y: x > y` type-checks fine
+  under `ty`/mypy/pyright and previously degraded silently instead of
+  erroring — for `min()` it could never signal "orders before" (always
+  returning the first element), while `max()`'s behavior happened to be
+  correct by coincidence. No static-typing trick can close this gap since
+  it's structural to Python, not a `type.py` alias choice. Also fixed 18
+  pre-existing tests across `tests/test_min.py`/`tests/test_max.py` that
+  were passing bool comparators and only passed today via first-element
+  luck (`min()`) or coincidence (`max()`); added regression tests asserting
+  the `TypeError` for `min()`/`max()`/`sorted()`, sync and async. Tracked as
+  **BREAKING** in README's migration log per `CLAUDE.md`.
 - Fixed the `Comparator` type alias mismatch (`type.py:16`): kept a single
   Java-style 3-way *int* `Comparator` (matching `sorted()`'s existing usage
   and Java's own `Stream.min/max(Comparator)`), rather than splitting into

--- a/src/snakestream/sort.py
+++ b/src/snakestream/sort.py
@@ -1,3 +1,8 @@
+def check_comparator_result_type(value: int) -> None:
+    if type(value) is not int:
+        raise TypeError(f"comparator must return an int (negative, zero, or positive), not {type(value).__name__}")
+
+
 async def merge_sort(arr, comparator):
     if len(arr) <= 1:
         return arr
@@ -14,7 +19,9 @@ async def _merge(left, right, comparator):
     i = 0
     j = 0
     while i < len(left) and j < len(right):
-        if await comparator(left[i], right[j]) <= 0:
+        sign = await comparator(left[i], right[j])
+        check_comparator_result_type(sign)
+        if sign <= 0:
             result.append(left[i])
             i += 1
         else:

--- a/src/snakestream/stream.py
+++ b/src/snakestream/stream.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Callable, Generator
 from snakestream.base_stream import BaseStream
 from snakestream.collector import to_generator
 from snakestream.exception import StreamBuildException
-from snakestream.sort import merge_sort
+from snakestream.sort import check_comparator_result_type, merge_sort
 from snakestream.type import R, T, Accumulator, CloseHandler, Comparator, Consumer, FlatMapper, Mapper, Predicate
 
 
@@ -133,7 +133,12 @@ class Stream(BaseStream):
                     # ty can't narrow `comparator`'s type via the runtime
                     # iscoroutinefunction() check above; this branch only
                     # runs for the sync `int`-returning half of the union.
-                    cache.sort(key=cmp_to_key(comparator))  # ty: ignore[invalid-argument-type]
+                    def checked_comparator(a, b):
+                        sign = comparator(a, b)
+                        check_comparator_result_type(sign)  # ty: ignore[invalid-argument-type]
+                        return sign
+
+                    cache.sort(key=cmp_to_key(checked_comparator))
             else:
                 cache.sort()
             # unblock the stream
@@ -231,8 +236,14 @@ class Stream(BaseStream):
             # iscoroutinefunction() check, so this is still typed
             # `int | Awaitable[int]` here even though it's always `int`.
             if iscoroutinefunction(comparator):
-                return await comparator(a, b)
-            return comparator(a, b)  # ty: ignore[invalid-return-type]
+                sign = await comparator(a, b)
+            else:
+                sign = comparator(a, b)
+            check_comparator_result_type(sign)  # ty: ignore[invalid-argument-type]
+            # sign is always `int` here (check_comparator_result_type raises
+            # otherwise), but ty can't narrow it past `int | Awaitable[int]`
+            # because of the iscoroutinefunction() branch above.
+            return sign  # ty: ignore[invalid-return-type]
 
         found = cast(T, _UNSET)
         async for raw in self._compose():

--- a/tests/test_max.py
+++ b/tests/test_max.py
@@ -9,16 +9,16 @@ from conftest import MyObject
 async def test_find_max_value_normal_input():
     input_list = [1, 2, 3, 4, 5]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == 5
 
 
 @pytest.mark.asyncio
 async def test_find_max_value_async_input():
-    async def async_comparator(x: int, y: int) -> bool:
+    async def async_comparator(x: int, y: int) -> int:
         await asyncio.sleep(0.01)
-        return x > y
+        return x - y
 
     input_list = [1, 2, 3, 4, 5]
     # when
@@ -31,7 +31,7 @@ async def test_find_max_value_async_input():
 async def test_find_max_value_empty_input():
     input_list = []
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it is None
 
@@ -40,13 +40,13 @@ async def test_find_max_value_empty_input():
 async def test_find_max_value_list_with_dupe_items():
     input_list = [1, 1, 2, 3, 4, 5]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == 5
 
     input_list = [1, 2, 3, 4, 5, 5]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == 5
 
@@ -55,7 +55,7 @@ async def test_find_max_value_list_with_dupe_items():
 async def test_find_max_value_negative_values():
     input_list = [-1, -2, -3, -4, -5]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == -1
 
@@ -64,7 +64,7 @@ async def test_find_max_value_negative_values():
 async def test_find_max_value_custom_comparator():
     input_list = ["a", "bb", "ccc"]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: len(x) > len(y))
+    it = await Stream.of(input_list).max(lambda x, y: len(x) - len(y))
     # then
     assert it == "ccc"
 
@@ -73,7 +73,7 @@ async def test_find_max_value_custom_comparator():
 async def test_find_max_value_with_falsy_values():
     input_list = [5, 0, 3, 4]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == 5
 
@@ -82,7 +82,7 @@ async def test_find_max_value_with_falsy_values():
 async def test_find_max_value_single_falsy_value():
     input_list = [0]
     # when
-    it = await Stream.of(input_list).max(lambda x, y: x > y)
+    it = await Stream.of(input_list).max(lambda x, y: x - y)
     # then
     assert it == 0
 
@@ -97,7 +97,7 @@ async def test_find_max_value_object_comparator() -> None:
         MyObject(2, "object2"),
         MyObject(3, "object3"),
     ]
-    it = await Stream.of(input_list).max(lambda x, y: x.id > y.id)
+    it = await Stream.of(input_list).max(lambda x, y: x.id - y.id)
     # then
     assert it == MyObject(3, "object3")
 
@@ -131,3 +131,23 @@ async def test_find_max_value_keeps_first_of_tied_elements():
     it = await Stream.of(input_list).max(lambda x, y: x[1] - y[1])
     # then
     assert it == ("a", 5)
+
+
+@pytest.mark.asyncio
+async def test_find_max_value_rejects_bool_comparator():
+    input_list = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(input_list).max(lambda x, y: x > y)
+
+
+@pytest.mark.asyncio
+async def test_find_max_value_rejects_async_bool_comparator():
+    async def async_comparator(x: int, y: int) -> bool:
+        await asyncio.sleep(0.01)
+        return x > y
+
+    input_list = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(input_list).max(async_comparator)

--- a/tests/test_min.py
+++ b/tests/test_min.py
@@ -9,16 +9,16 @@ from conftest import MyObject
 async def test_find_min_value_normal_input():
     input_list = [1, 2, 3, 4, 5]
     # when
-    it = await Stream.of(input_list).min(lambda x, y: x > y)
+    it = await Stream.of(input_list).min(lambda x, y: x - y)
     # then
     assert it == 1
 
 
 @pytest.mark.asyncio
 async def test_find_min_value_async_input():
-    async def async_comparator(x: int, y: int) -> bool:
+    async def async_comparator(x: int, y: int) -> int:
         await asyncio.sleep(0.01)
-        return x > y
+        return x - y
 
     input_list = [1, 2, 3, 4, 5]
     # when
@@ -31,7 +31,7 @@ async def test_find_min_value_async_input():
 async def test_find_min_value_empty_input():
     input_list = []
     # when
-    it = await Stream.of(input_list).min(lambda x, y: x > y)
+    it = await Stream.of(input_list).min(lambda x, y: x - y)
     # then
     assert it is None
 
@@ -40,13 +40,13 @@ async def test_find_min_value_empty_input():
 async def test_find_min_value_list_with_dupe_items():
     input_list = [1, 1, 2, 3, 4, 5]
     # when
-    it = await Stream.of(input_list).min(lambda x, y: x > y)
+    it = await Stream.of(input_list).min(lambda x, y: x - y)
     # then
     assert it == 1
 
     input_list = [1, 2, 3, 4, 5, 5]
     # when
-    it = await Stream.of(input_list).min(lambda x, y: x > y)
+    it = await Stream.of(input_list).min(lambda x, y: x - y)
     # then
     assert it == 1
 
@@ -64,7 +64,7 @@ async def test_find_min_value_negative_values():
 async def test_find_min_value_custom_comparator():
     input_list = ["a", "bb", "ccc"]
     # when
-    it = await Stream.of(input_list).min(lambda x, y: len(x) > len(y))
+    it = await Stream.of(input_list).min(lambda x, y: len(x) - len(y))
     # then
     assert it == "a"
 
@@ -82,7 +82,7 @@ async def test_find_min_value_with_falsy_values():
 async def test_find_min_value_single_falsy_value():
     input_list = [0]
     # when
-    it = await Stream.of(input_list).min(lambda x, y: x > y)
+    it = await Stream.of(input_list).min(lambda x, y: x - y)
     # then
     assert it == 0
 
@@ -97,7 +97,7 @@ async def test_find_min_value_object_comparator() -> None:
         MyObject(2, "object2"),
         MyObject(3, "object3"),
     ]
-    it = await Stream.of(input_list).min(lambda x, y: x.id > y.id)
+    it = await Stream.of(input_list).min(lambda x, y: x.id - y.id)
     # then
     assert it == MyObject(1, "object1")
 
@@ -131,3 +131,23 @@ async def test_find_min_value_keeps_first_of_tied_elements():
     it = await Stream.of(input_list).min(lambda x, y: x[1] - y[1])
     # then
     assert it == ("a", 5)
+
+
+@pytest.mark.asyncio
+async def test_find_min_value_rejects_bool_comparator():
+    input_list = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(input_list).min(lambda x, y: x > y)
+
+
+@pytest.mark.asyncio
+async def test_find_min_value_rejects_async_bool_comparator():
+    async def async_comparator(x: int, y: int) -> bool:
+        await asyncio.sleep(0.01)
+        return x > y
+
+    input_list = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(input_list).min(async_comparator)

--- a/tests/test_sorted.py
+++ b/tests/test_sorted.py
@@ -109,3 +109,23 @@ async def test_sorted_async_comparator_matches_cmp_to_key(values: list[int]) -> 
 
     # then
     assert actual == sorted(values, key=functools.cmp_to_key(_compare_by_abs))
+
+
+@pytest.mark.asyncio
+async def test_sorted_rejects_bool_comparator() -> None:
+    outset = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(outset).sorted(comparator=lambda a, b: a > b).collect(to_list)
+
+
+@pytest.mark.asyncio
+async def test_sorted_rejects_async_bool_comparator() -> None:
+    async def async_compare(a: int, b: int) -> bool:
+        await asyncio.sleep(0.01)
+        return a > b
+
+    outset = [3, 1, 2]
+    # when / then
+    with pytest.raises(TypeError):
+        await Stream.of(outset).sorted(comparator=async_compare).collect(to_list)


### PR DESCRIPTION
Comparator is typed Callable[[T, T], int | Awaitable[int]], but bool is a subclass of int in Python, so a bool-returning comparator like `lambda x, y: x > y` satisfies the type statically while silently violating the 3-way sign contract sorted()/min()/max() depend on. For min() this meant the comparator could never signal "orders before" (always returning the first element); max() happened to work by coincidence. Neither error was visible to callers or type checkers.

Adds check_comparator_result_type() (sort.py), used by _min_max() and both branches of sorted(), to raise TypeError when a comparator returns anything other than a plain int. Also fixes 18 pre-existing tests in test_min.py/test_max.py that were passing bool comparators and only passed via first-element luck or coincidence.

BREAKING: callers passing a bool-returning comparator to min()/max()/ sorted() now get an immediate TypeError instead of a silently wrong result.